### PR TITLE
VIRTS2524: More graceful exception handling

### DIFF
--- a/pyhuman/app/workflows/browse_web.py
+++ b/pyhuman/app/workflows/browse_web.py
@@ -21,9 +21,13 @@ class WebBrowse(BaseWorkflow):
     """ PRIVATE """
 
     def _web_browse(self):
-        with self.driver as d:
-            d.get('https://' + self._get_random_website())
-            sleep(2)
+        random_website = self._get_random_website()
+        try:
+            with self.driver as d:
+                d.get('https://' + random_website)
+                sleep(2)
+        except Exception as e:
+            print('Error loading random website %s: %s' % (random_website.rstrip(), e))
 
     def _get_random_website(self):
         return random.choice(self.website_list)

--- a/pyhuman/human.py
+++ b/pyhuman/human.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import os
 import random
+import sys
 from importlib import import_module
 from time import sleep
 
@@ -58,9 +59,14 @@ if __name__ == '__main__':
     parser.add_argument('--taskgroupinterval', type=int, default=GROUPING_INTERVAL_SECONDS)
     parser.add_argument('--extra', nargs='*', default=EXTRA_DEFAULTS)
     args = parser.parse_args()
-    run(
-        clustersize=args.clustersize,
-        taskinterval=args.taskinterval,
-        taskgroupinterval=args.taskgroupinterval,
-        extra=args.extra
-    )
+
+    try:
+        run(
+            clustersize=args.clustersize,
+            taskinterval=args.taskinterval,
+            taskgroupinterval=args.taskgroupinterval,
+            extra=args.extra
+        )
+    except KeyboardInterrupt:
+        print(" Terminating human execution...")
+        sys.exit()


### PR DESCRIPTION
## Description

When browsing to random websites, some website names are invalid or timeout on loading which raise selenium exceptions causing human to terminate unexpectedly. The proposed changes more gracefully handle these exceptions allowing human to continue execution despite browsing issues. Additionally, added a more graceful shutdown to human execution.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Generated human with "select a random website and browse" workflow
- Post deployment, overwrote websites.txt with some test websites that appear to cause problems. `ikea.com` appears to be one of the websites in the list that generates a timeout. Any non-existent website name can also generates name not resolved errors.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
