### PR TITLE
[VIRTS-3453] Single instance of Chrome

### DIFF
--- a/app/human_svc.py
+++ b/app/human_svc.py
@@ -44,7 +44,7 @@ class HumanService(BaseService):
     async def _load_workflow_module(self, root, workflow_file):
         module = os.path.join(root, workflow_file.split('.')[0]).replace(os.path.sep, '.')
         try:
-            loaded = getattr(import_module(module), 'load')(driver=None)
+            loaded = getattr(import_module(module), 'load')()
             await self.data_svc.store(Workflow(name=loaded.name, description=loaded.description, file=workflow_file))
         except Exception as e:
             self.log.error('Error loading extension=%s, %s' % (module, e))

--- a/app/human_svc.py
+++ b/app/human_svc.py
@@ -42,12 +42,14 @@ class HumanService(BaseService):
     """ PRIVATE """
 
     async def _load_workflow_module(self, root, workflow_file):
-        module = os.path.join(root, workflow_file.split('.')[0]).replace(os.path.sep, '.')
+        module_path = os.path.join(root, workflow_file.split('.')[0]).replace(os.path.sep, '.')
         try:
-            loaded = getattr(import_module(module), 'load')()
-            await self.data_svc.store(Workflow(name=loaded.name, description=loaded.description, file=workflow_file))
+            module = import_module(module_path)
+            workflow_name = getattr(module, 'WORKFLOW_NAME')
+            workflow_description = getattr(module, 'WORKFLOW_DESCRIPTION')
+            await self.data_svc.store(Workflow(name=workflow_name, description=workflow_description, file=workflow_file))
         except Exception as e:
-            self.log.error('Error loading extension=%s, %s' % (module, e))
+            self.log.error('Error loading extension=%s, %s' % (module_path, e))
 
     async def _create_windows_archive(self, payload_path, behaviors, name):
         file_name = name + '.zip'

--- a/pyhuman/app/utility/base_driver.py
+++ b/pyhuman/app/utility/base_driver.py
@@ -1,0 +1,22 @@
+from abc import abstractmethod
+
+
+class Singleton(type):
+    _instances = {}
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+class BaseDriverHelper(metaclass=Singleton):
+
+    __slots__ = ['name']
+
+    @abstractmethod
+    def __init__(self, name: str):
+        self.name = name
+
+    @abstractmethod
+    def cleanup(self):
+        ...

--- a/pyhuman/app/utility/base_workflow.py
+++ b/pyhuman/app/utility/base_workflow.py
@@ -10,7 +10,7 @@ class BaseWorkflow(object):
     __slots__ = ['name', 'description', 'driver']
 
     @abstractmethod
-    def __init__(self, name, description, driver):
+    def __init__(self, name, description, driver=None):
         self.name = name
         self.description = description
         self.driver = driver
@@ -18,3 +18,8 @@ class BaseWorkflow(object):
     @abstractmethod
     def action(self, extra=None):
         pass
+    
+    def cleanup(self):
+        if self.driver is None:
+            return
+        self.driver.cleanup()

--- a/pyhuman/app/utility/webdriver_helper.py
+++ b/pyhuman/app/utility/webdriver_helper.py
@@ -15,12 +15,6 @@ class WebDriverHelper(BaseDriverHelper):
     @property
     def driver(self):
         return self._driver
-
-    def __enter__(self):
-        return self._driver
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
     
     def cleanup(self):
         self._driver.quit()

--- a/pyhuman/app/utility/webdriver_helper.py
+++ b/pyhuman/app/utility/webdriver_helper.py
@@ -1,19 +1,29 @@
 from selenium import webdriver
 from webdriver_manager.chrome import ChromeDriverManager
 
+from .base_driver import BaseDriverHelper
 
-class WebDriverHelper:
+DRIVER_NAME = 'ChromeWebDriver'
+
+class WebDriverHelper(BaseDriverHelper):
 
     def __init__(self):
-        self.driver = None
+        super().__init__(name=DRIVER_NAME)
         self._driver_path = ChromeDriverManager().install()
+        self._driver = webdriver.Chrome(self._driver_path)
+
+    @property
+    def driver(self):
+        return self._driver
 
     def __enter__(self):
-        self.driver = webdriver.Chrome(self._driver_path)
-        return self.driver
+        return self._driver
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.driver.quit()
+        pass
+    
+    def cleanup(self):
+        self._driver.quit()
 
     """ PRIVATE """
 

--- a/pyhuman/app/workflows/browse_web.py
+++ b/pyhuman/app/workflows/browse_web.py
@@ -3,9 +3,10 @@ import random
 from time import sleep
 
 from ..utility.base_workflow import BaseWorkflow
+from ..utility.webdriver_helper import WebDriverHelper
 
-
-def load(driver):
+def load():
+    driver = WebDriverHelper()
     return WebBrowse(driver=driver)
 
 

--- a/pyhuman/app/workflows/browse_web.py
+++ b/pyhuman/app/workflows/browse_web.py
@@ -6,6 +6,9 @@ from ..utility.base_workflow import BaseWorkflow
 from ..utility.webdriver_helper import WebDriverHelper
 
 
+WORKFLOW_NAME = 'WebBrowser'
+WORKFLOW_DESCRIPTION = 'Select a random website and browse'
+
 DEFAULT_INPUT_WAIT_TIME = 2
 
 
@@ -17,7 +20,7 @@ def load():
 class WebBrowse(BaseWorkflow):
 
     def __init__(self, driver, input_wait_time=DEFAULT_INPUT_WAIT_TIME):
-        super().__init__(name='WebBrowser', description='Select a random website and browse', driver=driver)
+        super().__init__(name=WORKFLOW_NAME, description=WORKFLOW_DESCRIPTION, driver=driver)
 
         self.input_wait_time = input_wait_time
         self.website_list = self._load_website_list()

--- a/pyhuman/app/workflows/browse_web.py
+++ b/pyhuman/app/workflows/browse_web.py
@@ -5,6 +5,10 @@ from time import sleep
 from ..utility.base_workflow import BaseWorkflow
 from ..utility.webdriver_helper import WebDriverHelper
 
+
+DEFAULT_INPUT_WAIT_TIME = 2
+
+
 def load():
     driver = WebDriverHelper()
     return WebBrowse(driver=driver)
@@ -12,8 +16,10 @@ def load():
 
 class WebBrowse(BaseWorkflow):
 
-    def __init__(self, driver):
+    def __init__(self, driver, input_wait_time=DEFAULT_INPUT_WAIT_TIME):
         super().__init__(name='WebBrowser', description='Select a random website and browse', driver=driver)
+
+        self.input_wait_time = input_wait_time
         self.website_list = self._load_website_list()
 
     def action(self, extra=None):
@@ -25,7 +31,7 @@ class WebBrowse(BaseWorkflow):
         random_website = self._get_random_website()
         try:
             self.driver.driver.get('https://' + random_website)
-            sleep(2)
+            sleep(self.input_wait_time)
         except Exception as e:
             print('Error loading random website %s: %s' % (random_website.rstrip(), e))
 

--- a/pyhuman/app/workflows/browse_web.py
+++ b/pyhuman/app/workflows/browse_web.py
@@ -24,9 +24,8 @@ class WebBrowse(BaseWorkflow):
     def _web_browse(self):
         random_website = self._get_random_website()
         try:
-            with self.driver as d:
-                d.get('https://' + random_website)
-                sleep(2)
+            self.driver.driver.get('https://' + random_website)
+            sleep(2)
         except Exception as e:
             print('Error loading random website %s: %s' % (random_website.rstrip(), e))
 

--- a/pyhuman/app/workflows/execute_command.py
+++ b/pyhuman/app/workflows/execute_command.py
@@ -3,6 +3,10 @@ import subprocess
 from ..utility.base_workflow import BaseWorkflow
 
 
+WORKFLOW_NAME = 'ExecuteCommand'
+WORKFLOW_DESCRIPTION = 'Execute Custom Commands'
+
+
 def load():
     return ExecuteCommand()
 
@@ -10,7 +14,7 @@ def load():
 class ExecuteCommand(BaseWorkflow):
 
     def __init__(self):
-        super().__init__(name='ExecuteCommand', description='Execute Custom Commands')
+        super().__init__(name=WORKFLOW_NAME, description=WORKFLOW_DESCRIPTION)
 
     @staticmethod
     def action(extra=None):

--- a/pyhuman/app/workflows/execute_command.py
+++ b/pyhuman/app/workflows/execute_command.py
@@ -3,14 +3,14 @@ import subprocess
 from ..utility.base_workflow import BaseWorkflow
 
 
-def load(driver):
-    return ExecuteCommand(driver=driver)
+def load():
+    return ExecuteCommand()
 
 
 class ExecuteCommand(BaseWorkflow):
 
-    def __init__(self, driver):
-        super().__init__(name='ExecuteCommand', description='Execute Custom Commands', driver=driver)
+    def __init__(self):
+        super().__init__(name='ExecuteCommand', description='Execute Custom Commands')
 
     @staticmethod
     def action(extra=None):

--- a/pyhuman/app/workflows/google_search.py
+++ b/pyhuman/app/workflows/google_search.py
@@ -5,6 +5,9 @@ from ..utility.base_workflow import BaseWorkflow
 from ..utility.webdriver_helper import WebDriverHelper
 
 
+WORKFLOW_NAME = 'GoogleSearcher'
+WORKFLOW_DESCRIPTION = 'Search for something on Google'
+
 DEFAULT_INPUT_WAIT_TIME = 2
 
 
@@ -16,7 +19,7 @@ def load():
 class GoogleSearch(BaseWorkflow):
 
     def __init__(self, driver, input_wait_time=DEFAULT_INPUT_WAIT_TIME):
-        super().__init__(name='GoogleSearcher', description='Search for something on google', driver=driver)
+        super().__init__(name=WORKFLOW_NAME, description=WORKFLOW_DESCRIPTION, driver=driver)
 
         self.input_wait_time = input_wait_time
 

--- a/pyhuman/app/workflows/google_search.py
+++ b/pyhuman/app/workflows/google_search.py
@@ -5,15 +5,20 @@ from ..utility.base_workflow import BaseWorkflow
 from ..utility.webdriver_helper import WebDriverHelper
 
 
+DEFAULT_INPUT_WAIT_TIME = 2
+
+
 def load():
     driver = WebDriverHelper()
-    return SearchWeb(driver=driver)
+    return GoogleSearch(driver=driver)
 
 
-class SearchWeb(BaseWorkflow):
+class GoogleSearch(BaseWorkflow):
 
-    def __init__(self, driver):
-        super().__init__(name='WebSearcher', description='Search for something on google', driver=driver)
+    def __init__(self, driver, input_wait_time=DEFAULT_INPUT_WAIT_TIME):
+        super().__init__(name='GoogleSearcher', description='Search for something on google', driver=driver)
+
+        self.input_wait_time = input_wait_time
 
     def action(self, extra=None):
         self._search_web('MITRE Caldera')
@@ -25,9 +30,9 @@ class SearchWeb(BaseWorkflow):
         assert 'Google' in self.driver.driver.title
         elem = self.driver.driver.find_element_by_name('q')
         elem.clear()
-        sleep(2)
+        sleep(self.input_wait_time)
         elem.send_keys(search_string)
-        sleep(2)
+        sleep(self.input_wait_time)
         elem.send_keys(Keys.RETURN)
 
 

--- a/pyhuman/app/workflows/search_web.py
+++ b/pyhuman/app/workflows/search_web.py
@@ -21,15 +21,14 @@ class SearchWeb(BaseWorkflow):
     """ PRIVATE """
 
     def _search_web(self, search_string):
-        with self.driver as d:
-            d.get('https://www.google.com')
-            assert 'Google' in d.title
-            elem = d.find_element_by_name('q')
-            elem.clear()
-            sleep(2)
-            elem.send_keys(search_string)
-            sleep(2)
-            elem.send_keys(Keys.RETURN)
+        self.driver.driver.get('https://www.google.com')
+        assert 'Google' in self.driver.driver.title
+        elem = self.driver.driver.find_element_by_name('q')
+        elem.clear()
+        sleep(2)
+        elem.send_keys(search_string)
+        sleep(2)
+        elem.send_keys(Keys.RETURN)
 
 
 

--- a/pyhuman/app/workflows/search_web.py
+++ b/pyhuman/app/workflows/search_web.py
@@ -2,9 +2,11 @@ from selenium.webdriver.common.keys import Keys
 from time import sleep
 
 from ..utility.base_workflow import BaseWorkflow
+from ..utility.webdriver_helper import WebDriverHelper
 
 
-def load(driver):
+def load():
+    driver = WebDriverHelper()
     return SearchWeb(driver=driver)
 
 

--- a/pyhuman/app/workflows/spawn_shell.py
+++ b/pyhuman/app/workflows/spawn_shell.py
@@ -5,14 +5,14 @@ from time import sleep
 from ..utility.base_workflow import BaseWorkflow
 
 
-def load(driver):
-    return ListFiles(driver=driver)
+def load():
+    return ListFiles()
 
 
 class ListFiles(BaseWorkflow):
 
-    def __init__(self, driver):
-        super().__init__(name='ListFiles', description='List files in the current directory', driver=driver)
+    def __init__(self):
+        super().__init__(name='ListFiles', description='List files in the current directory')
 
     def action(self, extra=None):
         self._spawn_shell_and_quit()

--- a/pyhuman/app/workflows/spawn_shell.py
+++ b/pyhuman/app/workflows/spawn_shell.py
@@ -5,6 +5,10 @@ from time import sleep
 from ..utility.base_workflow import BaseWorkflow
 
 
+WORKFLOW_NAME = 'ListFiles'
+WORKFLOW_DESCRIPTION = 'List files in the current directory'
+
+
 def load():
     return ListFiles()
 
@@ -12,7 +16,7 @@ def load():
 class ListFiles(BaseWorkflow):
 
     def __init__(self):
-        super().__init__(name='ListFiles', description='List files in the current directory')
+        super().__init__(name=WORKFLOW_NAME, description=WORKFLOW_DESCRIPTION)
 
     def action(self, extra=None):
         self._spawn_shell_and_quit()

--- a/pyhuman/human.py
+++ b/pyhuman/human.py
@@ -1,12 +1,10 @@
 import argparse
-import json
+import signal
 import os
 import random
 import sys
 from importlib import import_module
 from time import sleep
-
-from app.utility.webdriver_helper import WebDriverHelper
 
 
 TASK_CLUSTER_COUNT = 5
@@ -25,31 +23,39 @@ def emulation_loop(workflows, clustersize, taskinterval, taskgroupinterval, extr
         sleep(random.randrange(taskgroupinterval))
 
 
-def import_workflows(webdriver_helper):
+def import_workflows():
     extensions = []
     for root, dirs, files in os.walk(os.path.join('app', 'workflows')):
         files = [f for f in files if not f[0] == '.' and not f[0] == "_"]
         dirs[:] = [d for d in dirs if not d[0] == '.' and not d[0] == "_"]
         for file in files:
-            extensions.append(load_module(root, file, webdriver_helper))
+            try:
+                extensions.append(load_module(root, file))
+            except Exception as e:
+                print('Error could not load workflow. {}'.format(e))
     return extensions
 
 
-def load_module(root, file, webdriver_helper):
+def load_module(root, file):
     module = os.path.join(root, file.split('.')[0]).replace(os.path.sep, '.')
-    try:
-        return getattr(import_module(module), 'load')(driver=webdriver_helper)
-    except Exception as e:
-        print('Error could not load workflow. {}'.format(e))
+    workflow_module = import_module(module)
+    return getattr(workflow_module, 'load')()
 
 
 def run(clustersize, taskinterval, taskgroupinterval, extra):
     random.seed()
-    webdriver_helper = WebDriverHelper()
-    if webdriver_helper.check_valid_driver_connection():
-        workflows = import_workflows(webdriver_helper=webdriver_helper)
-        emulation_loop(workflows=workflows, clustersize=clustersize, taskinterval=taskinterval,
-                       taskgroupinterval=taskgroupinterval, extra=extra)
+    workflows = import_workflows()
+
+    def signal_handler(sig, frame):
+        for workflow in workflows:
+            workflow.cleanup()
+        exit(0)
+    
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    emulation_loop(workflows=workflows, clustersize=clustersize, taskinterval=taskinterval,
+                    taskgroupinterval=taskgroupinterval, extra=extra)
 
 
 if __name__ == '__main__':

--- a/pyhuman/human.py
+++ b/pyhuman/human.py
@@ -25,12 +25,12 @@ def emulation_loop(workflows, clustersize, taskinterval, taskgroupinterval, extr
 
 def import_workflows():
     extensions = []
-    for root, dirs, files in os.walk(os.path.join('app', 'workflows')):
+    for root, dirs, files in os.walk(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'app', 'workflows')):
         files = [f for f in files if not f[0] == '.' and not f[0] == "_"]
         dirs[:] = [d for d in dirs if not d[0] == '.' and not d[0] == "_"]
         for file in files:
             try:
-                extensions.append(load_module(root, file))
+                extensions.append(load_module('app/workflows', file))
             except Exception as e:
                 print('Error could not load workflow. {}'.format(e))
     return extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 selenium==3.141.0
+webdriver-manager==3.5.2


### PR DESCRIPTION
## Description

These changes refactor the web driver related code to keep only one instance of Chrome open. This is done by changing the `WebDriverHelper` class to a Singleton that opens Chrome in its constructor. The same instance is then used by all web related workflows. They also make it so that only web related workflows need to contain a `WebDriverHelper`. Finally, signal handling was added to the main script to close Chrome when a kill signal is sent to the human since closing is not longer handled by a context manager.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I ran pyhuman will all existing workflows on both a a Windows machine with Chrome installed and a Linux machine without Chrome installed. The Windows machine made use of all four workflows successfully, while the Linux machine only made use of the two workflows that do not require Chrome.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
