### PR TITLE
Windows PyHuman bug fix and implement copy button

### DIFF
--- a/pyhuman/human.py
+++ b/pyhuman/human.py
@@ -37,7 +37,7 @@ def import_workflows():
 
 
 def load_module(root, file):
-    module = os.path.join(root, file.split('.')[0]).replace(os.path.sep, '.')
+    module = os.path.join(*root.split('/'), file.split('.')[0]).replace(os.path.sep, '.')
     workflow_module = import_module(module)
     return getattr(workflow_module, 'load')()
 

--- a/templates/human.html
+++ b/templates/human.html
@@ -131,11 +131,13 @@
                     </table>
                     <hr/>
                     <div class="box container">
-                        <a class="button is-small is-outlined cmd-copy-button" @click="copyCommandToClipboard();" x-show="window.isSecureContext">
-                            <span class="icon"><i class="far fa-lg fa-copy"></i></span>
-                            <span>Copy</span>
-                        </a>
-                        <br /><br />
+                        <div x-show="window.isSecureContext">
+                            <a class="button is-small is-outlined cmd-copy-button" @click="copyCommandToClipboard();">
+                                <span class="icon"><i class="far fa-lg fa-copy"></i></span>
+                                <span>Copy</span>
+                            </a>
+                            <br /><br />
+                        </div>
                         <code id="delivery-commands" style="text-align: left; font-size:14px;"></code>
                     </div>
                 </div>
@@ -295,6 +297,11 @@
             formatted_commands += '"' + command + '" ';
         });
         return formatted_commands;
+    }
+
+    function copyCommandToClipboard() {
+        const command = $('#delivery-commands')[0].innerText;
+        navigator.clipboard.writeText(command);
     }
 
     function getServerIP() {


### PR DESCRIPTION
## Description

Fixes a bug with running PyHuman on Windows where the workflow path string was not properly being parsed because Windows uses a `\` instead of a `/`.

Also implements the copy button that accidentally made its way into a prior merge.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested locally on Windows.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
