### PR TITLE
VIRTS 3491 - Add behavior to download random files

### DIFF
--- a/pyhuman/app/workflows/download_files.py
+++ b/pyhuman/app/workflows/download_files.py
@@ -4,7 +4,6 @@ from time import sleep
 import ssl
 import urllib.request
 
-
 from ..utility.base_workflow import BaseWorkflow
 
 
@@ -24,21 +23,13 @@ class DownloadFiles(BaseWorkflow):
     def action(self, extra=None):
         self._download_files()
 
+
+    """ PRIVATE """
     def _download_files(self):
         ssl._create_default_https_context = ssl._create_unverified_context
         file_url = 'https://imgs.xkcd.com/comics/file_transfer.png'
         urllib.request.urlretrieve(file_url, "file_downloaded.jpg")
         sleep(5)
 
-    """ PRIVATE """
 
-    # def _spawn_shell_and_quit(self):
-    #     p = subprocess.Popen(self._determine_os_shell_command(), shell=True)
-    #     sleep(5)
-    #     p.kill()
-    #
-    # @staticmethod
-    # def _determine_os_shell_command():
-    #     if sys.platform.startswith('win32') or sys.platform.startswith('cygwin'):
-    #         return 'dir'
-    #     return 'ls -la'
+

--- a/pyhuman/app/workflows/download_files.py
+++ b/pyhuman/app/workflows/download_files.py
@@ -1,6 +1,6 @@
 import subprocess
 import sys
-from time import sleep
+import os
 import ssl
 import urllib.request
 import json
@@ -32,23 +32,24 @@ class DownloadFiles(BaseWorkflow):
     """ PRIVATE """
     def _download_files(self):
         random_function_selector = [self._download_xkcd, self._download_wikipedia, self._download_nist]
-        random.choice(random_function_selector)()
+        dir = os.path.join(os.path.expanduser("~"), "Downloads")
+        random.choice(random_function_selector)(dir)
 
-    def _download_wikipedia(self):
+    def _download_wikipedia(self, dir):
         url = "https://en.wikipedia.org/wiki/Special:Random"
         r = requests.get(url, verify=False)
         wiki_name = "wiki" + str(random.randint(1, 100000)) + ".html"
-        open(wiki_name, 'wb').write(r.content)
+        open(os.path.join(dir, wiki_name), 'wb').write(r.content)
 
-    def _download_xkcd(self):
+    def _download_xkcd(self, dir):
         ssl._create_default_https_context = ssl._create_unverified_context
         xkcd_url = "https://xkcd.com/" + str(random.randint(1, 1000)) + "/info.0.json"
         request = urllib.request.urlopen(xkcd_url)
         pic_url = json.load(request)['img']
         pic_name = pic_url.split("https://imgs.xkcd.com/comics/", 1)[1]
-        urllib.request.urlretrieve(pic_url, pic_name)
+        urllib.request.urlretrieve(pic_url, os.path.join(dir, pic_name))
 
-    def _download_nist(self):
+    def _download_nist(self, dir):
         # Get random page of NIST search results
         nist_search_url = "https://www.nist.gov/publications/search?k=&t=&a=&ps=All&n=&d[min]=&d[max]=&page=" + str(random.randint(1, 2000))
         nist_search_text = requests.get(nist_search_url).text
@@ -64,4 +65,4 @@ class DownloadFiles(BaseWorkflow):
         if publication_download_link is not None:
             file_url = (publication_download_link.get('href'))
             file_name = publication_url.split("https://www.nist.gov/publications/", 1)[1] + ".pdf"
-            urllib.request.urlretrieve(file_url, file_name)
+            urllib.request.urlretrieve(file_url,  os.path.join(dir, file_name))

--- a/pyhuman/app/workflows/download_files.py
+++ b/pyhuman/app/workflows/download_files.py
@@ -1,5 +1,3 @@
-import subprocess
-import sys
 import os
 import ssl
 import urllib.request
@@ -8,6 +6,7 @@ import random
 import requests
 from bs4 import BeautifulSoup
 from random import choice
+from time import sleep
 
 from ..utility.base_workflow import BaseWorkflow
 
@@ -15,6 +14,7 @@ from ..utility.base_workflow import BaseWorkflow
 WORKFLOW_NAME = 'DownloadFiles'
 WORKFLOW_DESCRIPTION = 'Download files'
 
+DEFAULT_INPUT_WAIT_TIME = 2
 
 def load():
     return DownloadFiles()
@@ -22,8 +22,9 @@ def load():
 
 class DownloadFiles(BaseWorkflow):
 
-    def __init__(self):
+    def __init__(self, input_wait_time=DEFAULT_INPUT_WAIT_TIME):
         super().__init__(name=WORKFLOW_NAME, description=WORKFLOW_DESCRIPTION)
+        self.input_wait_time = input_wait_time
 
     def action(self, extra=None):
         self._download_files()
@@ -34,6 +35,7 @@ class DownloadFiles(BaseWorkflow):
         random_function_selector = [self._download_xkcd, self._download_wikipedia, self._download_nist]
         dir = os.path.join(os.path.expanduser("~"), "Downloads")
         random.choice(random_function_selector)(dir)
+        sleep(self.input_wait_time)
 
     def _download_wikipedia(self, dir):
         url = "https://en.wikipedia.org/wiki/Special:Random"

--- a/pyhuman/app/workflows/download_files.py
+++ b/pyhuman/app/workflows/download_files.py
@@ -3,6 +3,8 @@ import sys
 from time import sleep
 import ssl
 import urllib.request
+import json
+import random
 
 from ..utility.base_workflow import BaseWorkflow
 
@@ -21,15 +23,21 @@ class DownloadFiles(BaseWorkflow):
         super().__init__(name=WORKFLOW_NAME, description=WORKFLOW_DESCRIPTION)
 
     def action(self, extra=None):
-        self._download_files()
+        self._download_xkcd()
 
 
     """ PRIVATE """
-    def _download_files(self):
+    # def _download_files(self):
+    #     ssl._create_default_https_context = ssl._create_unverified_context
+    #     file_url = 'https://imgs.xkcd.com/comics/file_transfer.png'
+    #     urllib.request.urlretrieve(file_url, "file_downloaded.jpg")
+    #     sleep(5)
+
+    def _download_xkcd(self):
         ssl._create_default_https_context = ssl._create_unverified_context
-        file_url = 'https://imgs.xkcd.com/comics/file_transfer.png'
-        urllib.request.urlretrieve(file_url, "file_downloaded.jpg")
-        sleep(5)
-
-
+        xkcd_url = "https://xkcd.com/" + str(random.randint(1, 1000)) + "/info.0.json"
+        request = urllib.request.urlopen(xkcd_url)
+        pic_url = json.load(request)['img']
+        pic_name = pic_url.split("https://imgs.xkcd.com/comics/", 1)[1]
+        urllib.request.urlretrieve(pic_url, pic_name)
 

--- a/pyhuman/app/workflows/download_files.py
+++ b/pyhuman/app/workflows/download_files.py
@@ -50,7 +50,7 @@ class DownloadFiles(BaseWorkflow):
 
     def _download_nist(self):
         # Get random page of NIST search results
-        nist_search_url = self.get_random_nist_url()
+        nist_search_url = "https://www.nist.gov/publications/search?k=&t=&a=&ps=All&n=&d[min]=&d[max]=&page=" + str(random.randint(1, 2000))
         nist_search_text = requests.get(nist_search_url).text
         nist_search_soup = BeautifulSoup(nist_search_text, features="lxml")
         publications_links = (nist_search_soup.select('a[href^="/publications"]'))
@@ -65,8 +65,3 @@ class DownloadFiles(BaseWorkflow):
             file_url = (publication_download_link.get('href'))
             file_name = publication_url.split("https://www.nist.gov/publications/", 1)[1] + ".pdf"
             urllib.request.urlretrieve(file_url, file_name)
-
-    def get_random_nist_url(self):
-        # return "https://www.nist.gov/publications/search"
-        url = "https://www.nist.gov/publications/search?k=&t=&a=&ps=All&n=&d[min]=&d[max]=&page=" + str(random.randint(1, 2000))
-        return url

--- a/pyhuman/app/workflows/download_files.py
+++ b/pyhuman/app/workflows/download_files.py
@@ -1,0 +1,44 @@
+import subprocess
+import sys
+from time import sleep
+import ssl
+import urllib.request
+
+
+from ..utility.base_workflow import BaseWorkflow
+
+
+WORKFLOW_NAME = 'DownloadFiles'
+WORKFLOW_DESCRIPTION = 'Download files'
+
+
+def load():
+    return DownloadFiles()
+
+
+class DownloadFiles(BaseWorkflow):
+
+    def __init__(self):
+        super().__init__(name=WORKFLOW_NAME, description=WORKFLOW_DESCRIPTION)
+
+    def action(self, extra=None):
+        self._download_files()
+
+    def _download_files(self):
+        ssl._create_default_https_context = ssl._create_unverified_context
+        file_url = 'https://imgs.xkcd.com/comics/file_transfer.png'
+        urllib.request.urlretrieve(file_url, "file_downloaded.jpg")
+        sleep(5)
+
+    """ PRIVATE """
+
+    # def _spawn_shell_and_quit(self):
+    #     p = subprocess.Popen(self._determine_os_shell_command(), shell=True)
+    #     sleep(5)
+    #     p.kill()
+    #
+    # @staticmethod
+    # def _determine_os_shell_command():
+    #     if sys.platform.startswith('win32') or sys.platform.startswith('cygwin'):
+    #         return 'dir'
+    #     return 'ls -la'

--- a/pyhuman/app/workflows/download_files.py
+++ b/pyhuman/app/workflows/download_files.py
@@ -24,16 +24,13 @@ class DownloadFiles(BaseWorkflow):
         super().__init__(name=WORKFLOW_NAME, description=WORKFLOW_DESCRIPTION)
 
     def action(self, extra=None):
-        self._download_xkcd()
-        self._download_wikipedia()
+        self._download_files()
 
 
     """ PRIVATE """
-    # def _download_files(self):
-    #     ssl._create_default_https_context = ssl._create_unverified_context
-    #     file_url = 'https://imgs.xkcd.com/comics/file_transfer.png'
-    #     urllib.request.urlretrieve(file_url, "file_downloaded.jpg")
-    #     sleep(5)
+    def _download_files(self):
+        random_function_selector = [self._download_xkcd, self._download_wikipedia]
+        random.choice(random_function_selector)()
 
     def _download_wikipedia(self):
         url = "https://en.wikipedia.org/wiki/Special:Random"

--- a/pyhuman/app/workflows/download_files.py
+++ b/pyhuman/app/workflows/download_files.py
@@ -41,7 +41,10 @@ class DownloadFiles(BaseWorkflow):
 
     def _download_wikipedia(self, directory):
         url = "https://en.wikipedia.org/wiki/Special:Random"
-        request = requests.get(url, verify=False)
+        try:
+            request = requests.get(url, verify=False)
+        except urllib.error.URLError:
+            return
         file_name = "wiki" + str(random.randint(1, 100000)) + ".html"
         open(os.path.join(directory, file_name), 'wb').write(request.content)
 
@@ -49,10 +52,16 @@ class DownloadFiles(BaseWorkflow):
         # Disable certificate verification. Will display warning when run.
         ssl._create_default_https_context = ssl._create_unverified_context
         xkcd_url = "https://xkcd.com/" + str(random.randint(1, 1000)) + "/info.0.json"
-        request = urllib.request.urlopen(xkcd_url)
+        try:
+            request = urllib.request.urlopen(xkcd_url)
+        except urllib.error.URLError:
+            return
         pic_url = json.load(request)['img']
         pic_name = pic_url.split("https://imgs.xkcd.com/comics/", 1)[1]
-        urllib.request.urlretrieve(pic_url, os.path.join(directory, pic_name))
+        try:
+            urllib.request.urlretrieve(pic_url, os.path.join(directory, pic_name))
+        except urllib.error.URLError:
+            return
 
     def _download_nist(self, directory):
         # Get random page of NIST search results
@@ -70,4 +79,8 @@ class DownloadFiles(BaseWorkflow):
         if publication_download_link is not None:
             file_url = (publication_download_link.get('href'))
             file_name = publication_url.split("https://www.nist.gov/publications/", 1)[1] + ".pdf"
-            urllib.request.urlretrieve(file_url,  os.path.join(directory, file_name))
+            try:
+                urllib.request.urlretrieve(file_url,  os.path.join(directory, file_name))
+            except urllib.error.URLError:
+                return
+

--- a/pyhuman/app/workflows/download_files.py
+++ b/pyhuman/app/workflows/download_files.py
@@ -5,6 +5,7 @@ import ssl
 import urllib.request
 import json
 import random
+import requests
 
 from ..utility.base_workflow import BaseWorkflow
 
@@ -24,6 +25,7 @@ class DownloadFiles(BaseWorkflow):
 
     def action(self, extra=None):
         self._download_xkcd()
+        self._download_wikipedia()
 
 
     """ PRIVATE """
@@ -32,6 +34,12 @@ class DownloadFiles(BaseWorkflow):
     #     file_url = 'https://imgs.xkcd.com/comics/file_transfer.png'
     #     urllib.request.urlretrieve(file_url, "file_downloaded.jpg")
     #     sleep(5)
+
+    def _download_wikipedia(self):
+        url = "https://en.wikipedia.org/wiki/Special:Random"
+        r = requests.get(url, verify=False)
+        wiki_name = "wiki" + str(random.randint(1, 100000)) + ".html"
+        open(wiki_name, 'wb').write(r.content)
 
     def _download_xkcd(self):
         ssl._create_default_https_context = ssl._create_unverified_context

--- a/pyhuman/app/workflows/download_files.py
+++ b/pyhuman/app/workflows/download_files.py
@@ -46,6 +46,7 @@ class DownloadFiles(BaseWorkflow):
         open(os.path.join(directory, file_name), 'wb').write(request.content)
 
     def _download_xkcd(self, directory):
+        # Disable certificate verification. Will display warning when run.
         ssl._create_default_https_context = ssl._create_unverified_context
         xkcd_url = "https://xkcd.com/" + str(random.randint(1, 1000)) + "/info.0.json"
         request = urllib.request.urlopen(xkcd_url)
@@ -56,8 +57,8 @@ class DownloadFiles(BaseWorkflow):
     def _download_nist(self, directory):
         # Get random page of NIST search results
         nist_search_url = "https://www.nist.gov/publications/search?k=&t=&a=&ps=All&n=&d[min]=&d[max]=&page=" + str(random.randint(1, 2000))
-        nist_search_text = requests.get(nist_search_url).text
-        nist_search_soup = BeautifulSoup(nist_search_text, features="lxml")
+        nist_search_request = requests.get(nist_search_url).text
+        nist_search_soup = BeautifulSoup(nist_search_request, features="lxml")
         publications_links = (nist_search_soup.select('a[href^="/publications"]'))
 
         # Download random publication from the NIST search page

--- a/pyhuman/app/workflows/download_files.py
+++ b/pyhuman/app/workflows/download_files.py
@@ -16,6 +16,7 @@ WORKFLOW_DESCRIPTION = 'Download files'
 
 DEFAULT_INPUT_WAIT_TIME = 2
 
+
 def load():
     return DownloadFiles()
 
@@ -31,27 +32,28 @@ class DownloadFiles(BaseWorkflow):
 
 
     """ PRIVATE """
+
     def _download_files(self):
         random_function_selector = [self._download_xkcd, self._download_wikipedia, self._download_nist]
-        dir = os.path.join(os.path.expanduser("~"), "Downloads")
-        random.choice(random_function_selector)(dir)
+        directory = os.path.join(os.path.expanduser("~"), "Downloads")
+        random.choice(random_function_selector)(directory)
         sleep(self.input_wait_time)
 
-    def _download_wikipedia(self, dir):
+    def _download_wikipedia(self, directory):
         url = "https://en.wikipedia.org/wiki/Special:Random"
-        r = requests.get(url, verify=False)
-        wiki_name = "wiki" + str(random.randint(1, 100000)) + ".html"
-        open(os.path.join(dir, wiki_name), 'wb').write(r.content)
+        request = requests.get(url, verify=False)
+        file_name = "wiki" + str(random.randint(1, 100000)) + ".html"
+        open(os.path.join(directory, file_name), 'wb').write(request.content)
 
-    def _download_xkcd(self, dir):
+    def _download_xkcd(self, directory):
         ssl._create_default_https_context = ssl._create_unverified_context
         xkcd_url = "https://xkcd.com/" + str(random.randint(1, 1000)) + "/info.0.json"
         request = urllib.request.urlopen(xkcd_url)
         pic_url = json.load(request)['img']
         pic_name = pic_url.split("https://imgs.xkcd.com/comics/", 1)[1]
-        urllib.request.urlretrieve(pic_url, os.path.join(dir, pic_name))
+        urllib.request.urlretrieve(pic_url, os.path.join(directory, pic_name))
 
-    def _download_nist(self, dir):
+    def _download_nist(self, directory):
         # Get random page of NIST search results
         nist_search_url = "https://www.nist.gov/publications/search?k=&t=&a=&ps=All&n=&d[min]=&d[max]=&page=" + str(random.randint(1, 2000))
         nist_search_text = requests.get(nist_search_url).text
@@ -67,4 +69,4 @@ class DownloadFiles(BaseWorkflow):
         if publication_download_link is not None:
             file_url = (publication_download_link.get('href'))
             file_name = publication_url.split("https://www.nist.gov/publications/", 1)[1] + ".pdf"
-            urllib.request.urlretrieve(file_url,  os.path.join(dir, file_name))
+            urllib.request.urlretrieve(file_url,  os.path.join(directory, file_name))

--- a/pyhuman/requirements.txt
+++ b/pyhuman/requirements.txt
@@ -8,3 +8,5 @@ requests
 selenium
 urllib3
 webdriver-manager
+beautifulsoup4
+lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 selenium==3.141.0
 webdriver-manager==3.5.2
+beautifulsoup4


### PR DESCRIPTION
## Description

This PR adds a new behavior to download random files to the target to create noise and fill logs. There are 3 types of files that are downloaded: xkcd comics, NIST publications, and Wikipedia pages. The files are saved in ~/Downloads. This behavior can run on Windows, Mac, or Linux. 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
I ran the new behavior on my Mac, on a Windows VM, and on a Linux VM. I then confirmed that the files appeared in ~/Downloads. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
