### PR TITLE
VIRTS 3460 - Save paint files on Windows

### DIFF
--- a/pyhuman/app/workflows/ms_paint.py
+++ b/pyhuman/app/workflows/ms_paint.py
@@ -7,7 +7,7 @@ from ..utility.base_workflow import BaseWorkflow
 
 
 WORKFLOW_NAME = 'MicrosoftPaint'
-WORKFLOW_DESCRIPTION = 'Create a blank MS Paint file'
+WORKFLOW_DESCRIPTION = 'Create a blank MS Paint file (Windows)'
 
 DEFAULT_INPUT_WAIT_TIME = 2
 
@@ -34,12 +34,13 @@ class msPaint(BaseWorkflow):
         os.startfile(paint_path)
         # time.sleep(1)
         # pyautogui.click()
+        pyautogui.getWindowsWithTitle("Paint")
+        time.sleep(1)
         pyautogui.hotkey('ctrl', 's')
         file_name = int(time.time())
+        time.sleep(1)
         pyautogui.typewrite(str(file_name))
-        # time.sleep(1)
+        time.sleep(1)
         pyautogui.press('enter')
+        time.sleep(1)
         pyautogui.hotkey('alt', 'f4')
-
-
-

--- a/pyhuman/app/workflows/ms_paint.py
+++ b/pyhuman/app/workflows/ms_paint.py
@@ -1,6 +1,6 @@
 import os
-import time
 import pyautogui
+from time import sleep
 
 from ..utility.base_workflow import BaseWorkflow
 
@@ -27,16 +27,16 @@ class msPaint(BaseWorkflow):
     """ PRIVATE """
 
     @staticmethod
-    def _ms_paint():
+    def _ms_paint(self):
         paint_path = "C:\Windows\System32\mspaint.exe"
         os.startfile(paint_path)
         pyautogui.getWindowsWithTitle("Paint")
-        time.sleep(1)
+        sleep(self.input_wait_time)
         pyautogui.hotkey('ctrl', 's')
         file_name = int(time.time())
-        time.sleep(1)
+        sleep(self.input_wait_time)
         pyautogui.typewrite(str(file_name))
-        time.sleep(1)
+        sleep(self.input_wait_time)
         pyautogui.press('enter')
-        time.sleep(1)
+        sleep(self.input_wait_time)
         pyautogui.hotkey('alt', 'f4')

--- a/pyhuman/app/workflows/ms_paint.py
+++ b/pyhuman/app/workflows/ms_paint.py
@@ -3,8 +3,6 @@ import time
 import pyautogui
 
 from ..utility.base_workflow import BaseWorkflow
-# from ..utility.webdriver_helper import WebDriverHelper
-
 
 WORKFLOW_NAME = 'MicrosoftPaint'
 WORKFLOW_DESCRIPTION = 'Create a blank MS Paint file (Windows)'
@@ -32,8 +30,6 @@ class msPaint(BaseWorkflow):
     def _ms_paint():
         paint_path = "C:\Windows\System32\mspaint.exe"
         os.startfile(paint_path)
-        # time.sleep(1)
-        # pyautogui.click()
         pyautogui.getWindowsWithTitle("Paint")
         time.sleep(1)
         pyautogui.hotkey('ctrl', 's')

--- a/pyhuman/app/workflows/ms_paint.py
+++ b/pyhuman/app/workflows/ms_paint.py
@@ -1,42 +1,45 @@
 import os
-import pyautogui
-from time import sleep
+from importlib import import_module
+from time import sleep, time
 
 from ..utility.base_workflow import BaseWorkflow
+
 
 WORKFLOW_NAME = 'MicrosoftPaint'
 WORKFLOW_DESCRIPTION = 'Create a blank MS Paint file (Windows)'
 
 DEFAULT_INPUT_WAIT_TIME = 2
+DEFAULT_PAINT_PATH = paint_path = 'C:\Windows\System32\mspaint.exe'
 
 
 def load():
-    return msPaint()
+    pyautogui = import_module('pyautogui')
+    return msPaint(pyautogui=pyautogui)
 
 
 class msPaint(BaseWorkflow):
 
-    def __init__(self, input_wait_time=DEFAULT_INPUT_WAIT_TIME):
+    def __init__(self, pyautogui, input_wait_time=DEFAULT_INPUT_WAIT_TIME, paint_path=DEFAULT_PAINT_PATH):
         super().__init__(name=WORKFLOW_NAME, description=WORKFLOW_DESCRIPTION)
+
+        self.pyautogui = pyautogui
         self.input_wait_time = input_wait_time
+        self.paint_path = paint_path
 
     def action(self, extra=None):
         self._ms_paint()
 
-
     """ PRIVATE """
 
-    @staticmethod
     def _ms_paint(self):
-        paint_path = "C:\Windows\System32\mspaint.exe"
-        os.startfile(paint_path)
-        pyautogui.getWindowsWithTitle("Paint")
+        os.startfile(self.paint_path)
+        self.pyautogui.getWindowsWithTitle('Paint')
         sleep(self.input_wait_time)
-        pyautogui.hotkey('ctrl', 's')
-        file_name = int(time.time())
+        self.pyautogui.hotkey('ctrl', 's')
+        file_name = int(time())
         sleep(self.input_wait_time)
-        pyautogui.typewrite(str(file_name))
+        self.pyautogui.typewrite(str(file_name))
         sleep(self.input_wait_time)
-        pyautogui.press('enter')
+        self.pyautogui.press('enter')
         sleep(self.input_wait_time)
-        pyautogui.hotkey('alt', 'f4')
+        self.pyautogui.hotkey('alt', 'f4')

--- a/pyhuman/app/workflows/ms_paint.py
+++ b/pyhuman/app/workflows/ms_paint.py
@@ -1,0 +1,45 @@
+import os
+import time
+import pyautogui
+
+from ..utility.base_workflow import BaseWorkflow
+# from ..utility.webdriver_helper import WebDriverHelper
+
+
+WORKFLOW_NAME = 'MicrosoftPaint'
+WORKFLOW_DESCRIPTION = 'Create a blank MS Paint file'
+
+DEFAULT_INPUT_WAIT_TIME = 2
+
+
+def load():
+    return msPaint()
+
+
+class msPaint(BaseWorkflow):
+
+    def __init__(self, input_wait_time=DEFAULT_INPUT_WAIT_TIME):
+        super().__init__(name=WORKFLOW_NAME, description=WORKFLOW_DESCRIPTION)
+        self.input_wait_time = input_wait_time
+
+    def action(self, extra=None):
+        self._ms_paint()
+
+
+    """ PRIVATE """
+
+    @staticmethod
+    def _ms_paint():
+        paint_path = "C:\Windows\System32\mspaint.exe"
+        os.startfile(paint_path)
+        # time.sleep(1)
+        # pyautogui.click()
+        pyautogui.hotkey('ctrl', 's')
+        file_name = int(time.time())
+        pyautogui.typewrite(str(file_name))
+        # time.sleep(1)
+        pyautogui.press('enter')
+        pyautogui.hotkey('alt', 'f4')
+
+
+

--- a/pyhuman/app/workflows/ms_paint.py
+++ b/pyhuman/app/workflows/ms_paint.py
@@ -42,4 +42,5 @@ class msPaint(BaseWorkflow):
         sleep(self.input_wait_time)
         self.pyautogui.press('enter')
         sleep(self.input_wait_time)
+        self.pyautogui.getWindowsWithTitle('Paint')
         self.pyautogui.hotkey('alt', 'f4')

--- a/pyhuman/requirements.txt
+++ b/pyhuman/requirements.txt
@@ -4,6 +4,7 @@ colorama
 configparser
 crayons
 idna
+pyautogui
 requests
 selenium
 urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 selenium==3.141.0
 webdriver-manager==3.5.2
+pyautogui==0.9.53


### PR DESCRIPTION
## Description

This is a new human behavior that can be used on Windows systems that have Microsoft Paint installed as a prerequisite. 

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Ran the new behavior on a Windows VM and confirmed that the paint files were being saved to the VM.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
