### PR TITLE
VIRTS-3894 Autofill server IP using config value

### DIFF
--- a/templates/human.html
+++ b/templates/human.html
@@ -161,6 +161,8 @@
     $( document ).ready(function () {
         ['human-task-interval', 'human-cluster-interval', 'human-task-count'].forEach(elem => defaultNumberField(elem));
         stream('Design and generate a human to create noise on hosts');
+        document.getElementById("server-ip").placeholder = `${location.protocol}//${location.hostname}:${location.port}`;
+        document.getElementById("server-ip").value = `${location.protocol}//${location.hostname}:${location.port}`;
     });
 
     $('#duk-task-sleep-interval').click(function() {


### PR DESCRIPTION
## Description

The default value in the text box for CALDERA server IP address will now use the server IP value instead of using a hardcoded value of `http://localhost:8888`

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran CALDERA server and verified that the correct value for the server IP appears. Copied the command to start a human and successfully started the human on the target.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


