### PR TITLE
fixed arbitrary file move in human plugin

### DIFF
--- a/app/human_svc.py
+++ b/app/human_svc.py
@@ -22,7 +22,7 @@ class HumanService(BaseService):
 
     async def build_human(self, data):
         try:
-            name = data.pop('name')
+            _, name = os.path.split(data.pop('name'))
             await self._select_modules_and_compress(modules=data.pop('tasks'), name=name, platform=data.pop('platform'),
                                                     task_interval=data.pop('task_interval'), tasks_per_cluster=data.pop('task_count'),
                                                     task_cluster_interval=data.pop('task_cluster_interval'), extra=data.pop('extra', []))


### PR DESCRIPTION
## Description

Arbitrary file move found in human plugin, I am able to replace a .zip/.tar.gz file anywhere on the file system after naming my human with a filename containing ../'s. This issue has been fixed in all other features. As shown, after naming my human as '../../../../../../../home/kali/caldera/plugins/atomic/data/atomic-red-team/atomics/T1027/bin/T1027', the atomic red team TTP zip file is replaced (timestamp is changed).

![image](https://user-images.githubusercontent.com/71884484/177119978-d891d518-1233-4acd-84cd-8245840fda75.png)

![image](https://user-images.githubusercontent.com/71884484/177119996-d81b83f6-b561-4c03-ac85-7db8f7f65706.png)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

Checked using debug statements.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
