### PR TITLE
Include NIST downloads

### DIFF
--- a/pyhuman/app/workflows/download_files.py
+++ b/pyhuman/app/workflows/download_files.py
@@ -34,8 +34,7 @@ class DownloadFiles(BaseWorkflow):
     """ PRIVATE """
 
     def _download_files(self):
-        random_function_selector = [self._download_xkcd, self._download_wikipedia]
-        # random_function_selector = [self._download_xkcd, self._download_wikipedia, self._download_nist]
+        random_function_selector = [self._download_xkcd, self._download_wikipedia, self._download_nist]
         directory = os.path.join(os.path.expanduser("~"), "Downloads")
         random.choice(random_function_selector)(directory)
         sleep(self.input_wait_time)


### PR DESCRIPTION
## Description

Include the NIST download feature of the download behavior, now that the NIST website search/downloads have been fixed.

## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran human on mac and confirmed that all 3 types of downloads appeared in ~/Downloads


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code

